### PR TITLE
Moved CSV from mount to copy

### DIFF
--- a/Docker/graylog/Dockerfile
+++ b/Docker/graylog/Dockerfile
@@ -3,5 +3,6 @@ FROM graylog/graylog:3.1
 USER root
 RUN mkdir -pv /etc/graylog/server/
 COPY ./getGeo.sh /etc/graylog/server/
+COPY ./service-names-port-numbers.csv /etc/graylog/server/
 RUN chmod +x /etc/graylog/server/getGeo.sh && /etc/graylog/server/getGeo.sh
 USER graylog


### PR DESCRIPTION
Since we are already creating an overlay image, we might as well move it here.  In one of my builds it was build mounted as a directory.  Probably just my docker syntax, but completely avoidable if we copy it from here.